### PR TITLE
[Doc] add instruction to set rust nightly and use unstable features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Install `clang` (optional, to compile executable).
 
 Compile the compiler:
 ```sh
+$ rustup default nightly
 $ rustc src/main.rs -o goat
 ```
 


### PR DESCRIPTION
See `rustc --explain E0658`